### PR TITLE
Add unmock-jest-runner

### DIFF
--- a/2.test.js
+++ b/2.test.js
@@ -1,10 +1,10 @@
 const unmock = require("unmock");
+const runner = require("unmock-jest-runner").default;
 const getUsersForUI = require("./users");
 
 const {
   u,
-  transform: { withCodes, responseBody },
-  runner
+  transform: { withCodes, responseBody }
 } = unmock;
 
 unmock

--- a/3.test.js
+++ b/3.test.js
@@ -1,9 +1,9 @@
 const unmock = require("unmock");
+const runner = require("unmock-jest-runner").default;
 const getUsersForUI = require("./users");
 
 const {
-  u,
-  runner
+  u
 } = unmock;
 
 unmock

--- a/4.test.js
+++ b/4.test.js
@@ -1,9 +1,9 @@
 const unmock = require("unmock");
+const runner = require("unmock-jest-runner").default;
 const axios = require("axios");
 
 const {
-  transform: { withCodes, responseBody },
-  runner
+  transform: { withCodes, responseBody }
 } = unmock;
 
 let petstore;

--- a/package-lock.json
+++ b/package-lock.json
@@ -150,9 +150,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
-      "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
+      "integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
       "requires": {
         "regenerator-runtime": "^0.13.2"
       }
@@ -387,18 +387,47 @@
         "@types/yargs": "^13.0.0"
       }
     },
+    "@meeshkanml/json-schema-faker": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@meeshkanml/json-schema-faker/-/json-schema-faker-0.0.2.tgz",
+      "integrity": "sha512-NyuW1hD6W2eHMN58vDpYiRGkZKQaZN/nZyYa5Z6j2ajp3vHlDpDPYGOldAdi7tIxH9QNFUgvRadoUBfgNIv+0w==",
+      "requires": {
+        "@meeshkanml/json-schema-ref-parser": "0.0.0",
+        "jsonpath-plus": "^1.0.0",
+        "randexp": "^0.5.3"
+      }
+    },
+    "@meeshkanml/json-schema-ref-parser": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@meeshkanml/json-schema-ref-parser/-/json-schema-ref-parser-0.0.0.tgz",
+      "integrity": "sha512-NI+0dbUzllLPHVS5rbF9e7qUp9pbkbHn5uMAHmBy43CvGD5EfkTQTRjBB2wE5lSv5eLXICVNC4sZGPU9vLTt5g==",
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^3.13.1",
+        "ono": "^5.1.0",
+        "url": "^0.11.0"
+      }
+    },
+    "@meeshkanml/jsonschema": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@meeshkanml/jsonschema/-/jsonschema-0.0.1.tgz",
+      "integrity": "sha512-p/B7xS6hK0umAG2qEtdca6/yIwfBYEY+OFM/FwS6IpHdUpqOQ1AH5++KI45hCv5tBjxz8IebFzkIRFifXPXI0Q==",
+      "requires": {
+        "url-parse": "^1.4.7"
+      }
+    },
     "@sinonjs/commons": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",
-      "integrity": "sha512-w4/WHG7C4WWFyE5geCieFJF6MZkbW4VAriol5KlmQXpAQdxvV0p26sqNZOW6Qyw6Y0l9K4g+cHvvczR2sEEpqg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.0.tgz",
+      "integrity": "sha512-qbk9AP+cZUsKdW1GJsBpxPKFmCJ0T8swwzVje3qFd+AkQb74Q/tiuzrdfFg8AD2g5HH/XbE/I8Uc1KYHVYWfhg==",
       "requires": {
         "type-detect": "4.0.8"
       }
     },
     "@sinonjs/formatio": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
-      "integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
+      "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
       "requires": {
         "@sinonjs/commons": "^1",
         "@sinonjs/samsam": "^3.1.0"
@@ -460,6 +489,11 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/debug": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
+      "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -483,27 +517,45 @@
       }
     },
     "@types/node": {
-      "version": "12.7.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.11.tgz",
-      "integrity": "sha512-Otxmr2rrZLKRYIybtdG/sgeO+tHY20GxeDjcGmUnmmlCWyEnv2a2x1ZXBo3BTec4OiTXMQCiazB8NMBf0iRlFw=="
+      "version": "13.7.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.1.tgz",
+      "integrity": "sha512-Zq8gcQGmn4txQEJeiXo/KiLpon8TzAl0kmKH4zdWctPj05nWwp1ClMdAVEloqrQKfaC48PNLdgN/aVaLqUrluA=="
     },
     "@types/node-fetch": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.2.tgz",
-      "integrity": "sha512-djYYKmdNRSBtL1x4CiE9UJb9yZhwtI1VC+UxZD0psNznrUj80ywsxKlEGAE+QL1qvLjPbfb24VosjkYM6W4RSQ==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.4.tgz",
+      "integrity": "sha512-Oz6id++2qAOFuOlE1j0ouk1dzl3mmI1+qINPNBhi9nt/gVOz0G+13Ao6qjhdF0Ys+eOkhu6JnFmt38bR3H0POQ==",
       "requires": {
         "@types/node": "*"
       }
     },
+    "@types/readline-sync": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@types/readline-sync/-/readline-sync-1.4.3.tgz",
+      "integrity": "sha512-YP9NVli96E+qQLAF2db+VjnAUEeZcFVg4YnMgr8kpDUFwQBnj31rPLOVHmazbKQhaIkJ9cMHsZhpKdzUeL0KTg=="
+    },
     "@types/sinon": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.0.tgz",
-      "integrity": "sha512-NyzhuSBy97B/zE58cDw4NyGvByQbAHNP9069KVSgnXt/sc0T6MFRh0InKAeBVHJWdSXG1S3+PxgVIgKo9mTHbw=="
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.1.tgz",
+      "integrity": "sha512-EZQUP3hSZQyTQRfiLqelC9NMWd1kqLcmQE0dMiklxBkgi84T+cHOhnKpgk4NnOWpGX863yE6+IaGnOXUNFqDnQ=="
     },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw=="
+    },
+    "@types/url-parse": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@types/url-parse/-/url-parse-1.4.3.tgz",
+      "integrity": "sha512-4kHAkbV/OfW2kb5BLVUuUMoumB3CP8rHqlw48aHvFy5tf9ER0AfOonBlX29l/DD68G70DmyhRlSYfQPSYpC5Vw=="
+    },
+    "@types/whatwg-url": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-6.4.0.tgz",
+      "integrity": "sha512-tonhlcbQ2eho09am6RHnHOgvtDfDYINd5rgxD+2YSkKENooVCFsWizJz139MQW/PV8FfClyKrNe9ZbdHrSCxGg==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/yargs": {
       "version": "13.0.2",
@@ -574,14 +626,6 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
       "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ=="
-    },
-    "ansi-align": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
-      "integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
-      "requires": {
-        "string-width": "^3.0.0"
-      }
     },
     "ansi-escapes": {
       "version": "3.2.0",
@@ -836,6 +880,11 @@
         }
       }
     },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -857,21 +906,6 @@
         "json-to-ast": "^2.0.3",
         "jsonpointer": "^4.0.1",
         "leven": "^3.1.0"
-      }
-    },
-    "boxen": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-3.2.0.tgz",
-      "integrity": "sha512-cU4J/+NodM3IHdSL2yN8bqYqnmlBTidDR4RC7nJs61ZmtGz8VZzM3HLQX0zY5mrSmPtR3xWwsq2jOUQqFZN8+A==",
-      "requires": {
-        "ansi-align": "^3.0.0",
-        "camelcase": "^5.3.1",
-        "chalk": "^2.4.2",
-        "cli-boxes": "^2.2.0",
-        "string-width": "^3.0.0",
-        "term-size": "^1.2.0",
-        "type-fest": "^0.3.0",
-        "widest-line": "^2.0.0"
       }
     },
     "brace-expansion": {
@@ -940,6 +974,15 @@
       "dev": true,
       "requires": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "buffer": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+      "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
       }
     },
     "buffer-from": {
@@ -1035,11 +1078,6 @@
           }
         }
       }
-    },
-    "cli-boxes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
-      "integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w=="
     },
     "cliui": {
       "version": "5.0.0",
@@ -1170,14 +1208,23 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-js": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
-      "integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw=="
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
+      "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
     },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cross-fetch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.4.tgz",
+      "integrity": "sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==",
+      "requires": {
+        "node-fetch": "2.6.0",
+        "whatwg-fetch": "3.0.0"
+      }
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -1378,7 +1425,8 @@
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
     },
     "enabled": {
       "version": "1.0.2",
@@ -1397,9 +1445,9 @@
       }
     },
     "env-variable": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.5.tgz",
-      "integrity": "sha512-zoB603vQReOFvTg5xMl9I1P2PnHsHQQKTEowsKKD7nseUfJq6UWzK+4YtlWUO1nhiQUxe6XMkk+JleSZD1NZFA=="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.6.tgz",
+      "integrity": "sha512-bHz59NlBbtS0NhftmR8+ExBEekE7br0e01jw+kk0NDro7TtZzBYZ5ScGPs3OmwnpyfHTHOtr1Y6uedCdrIldtg=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -1750,15 +1798,10 @@
         "mime-types": "^2.1.12"
       }
     },
-    "format-util": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.3.tgz",
-      "integrity": "sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU="
-    },
     "fp-ts": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.1.0.tgz",
-      "integrity": "sha512-2xTHhLuP0uLjpaHAARpGQ1TpIPqEUMu8fGN5jv8py0T+HgB6a4bV57p5EQoOyeHws4SuYxiUi2/m0isHs6F/cA=="
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.4.4.tgz",
+      "integrity": "sha512-J5wFa/BzT57A+DIvwAYS5LTsbRiXsvF9hsefP3ZfzsHLuWGjtHAheG1WscG1tX3og1PDZyv6mZAUTlpH1MmHhA=="
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -2507,6 +2550,11 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
     "import-local": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
@@ -2557,9 +2605,9 @@
       "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
     },
     "io-ts": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.0.1.tgz",
-      "integrity": "sha512-RezD+WcCfW4VkMkEcQWL/Nmy/nqsWTvTYg7oUmTGzglvSSV2P9h2z1PVeREPFf0GWNzruYleAt1XCMQZSg1xxQ=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.1.0.tgz",
+      "integrity": "sha512-GnTYtJRVu8L9QEhJrkJBaVr6aR13IBH+MEIeq0WW0IE1zIk9XzMNqqf220p8InJGYwuoHNTVsHDvBQzFIp4ieg=="
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -3391,16 +3439,6 @@
         "valid-url": "~1.0.9"
       }
     },
-    "json-schema-faker": {
-      "version": "0.5.0-rc19",
-      "resolved": "https://registry.npmjs.org/json-schema-faker/-/json-schema-faker-0.5.0-rc19.tgz",
-      "integrity": "sha512-yJLDodgoc/BOONGFmyuKoj3bSRXZ55FWIp1WjN0yC76kfoIz+lI5ttjUtU8NxgNULGFppJzpUM0ydyAWH3qp7A==",
-      "requires": {
-        "json-schema-ref-parser": "^6.1.0",
-        "jsonpath-plus": "^1.0.0",
-        "randexp": "^0.5.3"
-      }
-    },
     "json-schema-poet": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/json-schema-poet/-/json-schema-poet-0.0.9.tgz",
@@ -3409,16 +3447,6 @@
         "fp-ts": "^2.0.5",
         "io-ts": "^2.0.1",
         "json-schema-strictly-typed": "^0.0.14"
-      }
-    },
-    "json-schema-ref-parser": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-6.1.0.tgz",
-      "integrity": "sha512-pXe9H1m6IgIpXmE5JSb8epilNTGsmTb2iPohAXpOdhqGFbQjNeHHsZxU+C8w6T81GZxSPFLeUoqDJmzxx5IGuw==",
-      "requires": {
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^3.12.1",
-        "ono": "^4.0.11"
       }
     },
     "json-schema-strictly-typed": {
@@ -3467,11 +3495,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
-    },
-    "jsonschema": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
-      "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -3597,8 +3620,7 @@
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-      "dev": true
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
     },
     "logform": {
       "version": "2.1.2",
@@ -3631,15 +3653,6 @@
       "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
-      }
-    },
-    "lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
       }
     },
     "make-dir": {
@@ -3819,9 +3832,9 @@
       }
     },
     "monocle-ts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/monocle-ts/-/monocle-ts-2.0.0.tgz",
-      "integrity": "sha512-vPM02WypUz0Xo2MtLUPgvdelCRn70VT05pdAB7qmHJSNY4CAoQt3ClpH77AG3yZk7PY8CA6++ezHcENUDOiuEA=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/monocle-ts/-/monocle-ts-2.1.0.tgz",
+      "integrity": "sha512-YWH8TDcZSEeCaxp0ZjgccLChnaDvTiUHILpuI0DSZeASYSCgwdz+h6+uEG4QCwYreGsn1oI18ysrcUPv6xWK7w=="
     },
     "ms": {
       "version": "2.0.0",
@@ -3871,15 +3884,25 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "nise": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.2.tgz",
-      "integrity": "sha512-/6RhOUlicRCbE9s+94qCUsyE+pKlVJ5AhIv+jEE7ESKwnbXqulKZ1FYU+XAtHHWE9TinYvAxDUJAb912PwPoWA==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.3.tgz",
+      "integrity": "sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==",
       "requires": {
         "@sinonjs/formatio": "^3.2.1",
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
-        "lolex": "^4.1.0",
+        "lolex": "^5.0.1",
         "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "lolex": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
+          "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
+          "requires": {
+            "@sinonjs/commons": "^1.7.0"
+          }
+        }
       }
     },
     "node-fetch": {
@@ -3977,23 +4000,23 @@
       }
     },
     "oas-linter": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/oas-linter/-/oas-linter-3.0.1.tgz",
-      "integrity": "sha512-vk8Pzqq8iZM8V0/8NJMHAbf4CMyAUnLTJPNKwCkFl6g2W7omomL3yPpseNqihwU7KgqwYDTjxJ31qavmYbeDbg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/oas-linter/-/oas-linter-3.0.2.tgz",
+      "integrity": "sha512-E2bpo6/x/q1dYCcsqs8yCvp+lYBaODNnxewgtDIT4FhaHjB3u/0DpRl3RNk23SLeaUn4F3qqbczrkK8FXWrYNQ==",
       "requires": {
         "should": "^13.2.1",
-        "yaml": "^1.3.1"
+        "yaml": "^1.7.2"
       }
     },
     "oas-resolver": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/oas-resolver/-/oas-resolver-2.2.5.tgz",
-      "integrity": "sha512-AwARII3hmdXtDAGccvjVsRLked0PNJycIG/koD6lYoGspJjxnQ3a8AmDgp7kHYnG148zusfsl8GM0cfwGmd7EA==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/oas-resolver/-/oas-resolver-2.2.7.tgz",
+      "integrity": "sha512-NwjOBSvPZRFOUdT79DFuyRM6auq8eS4V2U8GkLmzhawVU6jYY7JXRd8oghlo7dEqt+P1LF58uHtCsumUiENXtA==",
       "requires": {
         "node-fetch-h2": "^2.3.0",
         "oas-kit-common": "^1.0.7",
-        "reftools": "^1.0.8",
-        "yaml": "^1.3.1",
+        "reftools": "^1.0.10",
+        "yaml": "^1.7.2",
         "yargs": "^12.0.5"
       },
       "dependencies": {
@@ -4117,20 +4140,20 @@
       "integrity": "sha512-Q9xqeUtc17ccP/dpUfARci4kwFFszyJAgR/wbDhrRR/73GqsY5uSmKaIK+RmBqO8J4jVYrrDPjQKvt1IcpQdGw=="
     },
     "oas-validator": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/oas-validator/-/oas-validator-3.3.1.tgz",
-      "integrity": "sha512-WFKafxpH2KrxHG6drJiJ7M0mzGZER3XDkLtbeX8z9YNR4JvCMDlhQL7J2i+rnCxyVC8riRZGGeZpxQ0000w2HA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/oas-validator/-/oas-validator-3.3.3.tgz",
+      "integrity": "sha512-zdVSils8UNud1CW9pbko3WJX3YLMfUMEVzqAqNuX8+wm8qpmmwL1xZr5uOQLiK8a7yun7Kqs4f2xRzY+e+HlPw==",
       "requires": {
         "ajv": "^5.5.2",
-        "better-ajv-errors": "^0.5.2",
+        "better-ajv-errors": "^0.6.7",
         "call-me-maybe": "^1.0.1",
         "oas-kit-common": "^1.0.7",
-        "oas-linter": "^3.0.1",
-        "oas-resolver": "^2.2.5",
+        "oas-linter": "^3.0.2",
+        "oas-resolver": "^2.2.7",
         "oas-schema-walker": "^1.1.2",
-        "reftools": "^1.0.8",
+        "reftools": "^1.0.10",
         "should": "^13.2.1",
-        "yaml": "^1.3.1"
+        "yaml": "^1.7.2"
       },
       "dependencies": {
         "ajv": {
@@ -4144,25 +4167,6 @@
             "json-schema-traverse": "^0.3.0"
           }
         },
-        "better-ajv-errors": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/better-ajv-errors/-/better-ajv-errors-0.5.7.tgz",
-          "integrity": "sha512-O7tpXektKWVwYCH5g6Vs3lKD+sJs7JHh5guapmGJd+RTwxhFZEf4FwvbHBURUnoXsTeFaMvGuhTTmEGiHpNi6w==",
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/runtime": "^7.0.0",
-            "chalk": "^2.4.1",
-            "core-js": "^2.5.7",
-            "json-to-ast": "^2.0.3",
-            "jsonpointer": "^4.0.1",
-            "leven": "^2.1.0"
-          }
-        },
-        "core-js": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
-        },
         "fast-deep-equal": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
@@ -4172,11 +4176,6 @@
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
           "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
-        },
-        "leven": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-          "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
         }
       }
     },
@@ -4260,19 +4259,16 @@
       "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4="
     },
     "ono": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/ono/-/ono-4.0.11.tgz",
-      "integrity": "sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==",
-      "requires": {
-        "format-util": "^1.0.3"
-      }
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ono/-/ono-5.1.0.tgz",
+      "integrity": "sha512-GgqRIUWErLX4l9Up0khRtbrlH8Fyj59A0nKv8V6pWEto38aUgnOGOOF7UmgFFLzFnDSc8REzaTXOc0hqEe7yIw=="
     },
     "openapi-refinements": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/openapi-refinements/-/openapi-refinements-0.3.8.tgz",
-      "integrity": "sha512-xlIZ2NR/ThugZqVRJkgj+90HpIlfOxlMtRxguGnDBO/A3xnV7Vfb/1xJmvx6jngqUUY9PfS7qjUkexzY4OQPNA==",
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/openapi-refinements/-/openapi-refinements-0.3.12.tgz",
+      "integrity": "sha512-Z6Fj95f1Z3RhKzMaQrnvrQeO/F/K0FE6DNPTkpyRzWJrpgjRypc/QalcGyvsU0VsTkAghXSqFmgimY/nC4qdaw==",
       "requires": {
-        "jsonschema": "^1.2.4"
+        "@meeshkanml/jsonschema": "^0.0.1"
       }
     },
     "optimist": {
@@ -4419,9 +4415,9 @@
       "dev": true
     },
     "path-to-regexp": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
       "requires": {
         "isarray": "0.0.1"
       },
@@ -4490,9 +4486,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
-      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw=="
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew=="
     },
     "pretty-format": {
       "version": "24.9.0",
@@ -4519,11 +4515,6 @@
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.3"
       }
-    },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
       "version": "1.3.0",
@@ -4552,9 +4543,9 @@
       "dev": true
     },
     "query-string": {
-      "version": "6.8.3",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.8.3.tgz",
-      "integrity": "sha512-llcxWccnyaWlODe7A9hRjkvdCKamEKTh+wH8ITdTc3OhchaqUZteiSCX/2ablWHVrkVIe04dntnaZJ7BdyW0lQ==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.10.1.tgz",
+      "integrity": "sha512-SHTUV6gDlgMXg/AQUuLpTiBtW/etZ9JT6k6RCtCyqADquApLX0Aq5oK/s5UeTUAWBG50IExjIr587GqfXRfM4A==",
       "requires": {
         "decode-uri-component": "^0.2.0",
         "split-on-first": "^1.0.0",
@@ -4565,6 +4556,11 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "querystringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
+      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
     },
     "randexp": {
       "version": "0.5.3",
@@ -4609,14 +4605,19 @@
       }
     },
     "readable-stream": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-      "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
+      "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
         "util-deprecate": "^1.0.1"
       }
+    },
+    "readline-sync": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
+      "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw=="
     },
     "realpath-native": {
       "version": "1.1.0",
@@ -4628,9 +4629,9 @@
       }
     },
     "reftools": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/reftools/-/reftools-1.0.8.tgz",
-      "integrity": "sha512-hERpM8J+L0q8dzKFh/QqcLlKZYmTgzGZM7m8b1ptS66eg4NA/iMPm7GNw3TKZ876ndVjGpiLt0BCIfAWsUgwGg=="
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reftools/-/reftools-1.0.10.tgz",
+      "integrity": "sha512-ZWFZp5mi+MhJE4TvgwzuxlwnVw+6COn1MRKWljjvhlzGc/ltufCNyMVUStD+iMC/lr89Pb1HyrOHIGGSv64ZjA=="
     },
     "regenerator-runtime": {
       "version": "0.13.3",
@@ -4738,6 +4739,11 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.12.0",
@@ -5260,6 +5266,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
       "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
       "requires": {
         "emoji-regex": "^7.0.1",
         "is-fullwidth-code-point": "^2.0.0",
@@ -5285,6 +5292,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
       "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
       "requires": {
         "ansi-regex": "^4.1.0"
       }
@@ -5309,20 +5317,20 @@
       }
     },
     "swagger2openapi": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/swagger2openapi/-/swagger2openapi-5.3.1.tgz",
-      "integrity": "sha512-2EIs1gJs9LH4NjrxHPJs6N0Kh9pg66He+H9gIcfn1Q9dvdqPPVTC2NRdXalqT+98rIoV9kSfAtNBD4ASC0Q1mg==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/swagger2openapi/-/swagger2openapi-5.3.3.tgz",
+      "integrity": "sha512-RZ4ybueFFoiairWHMXEJnCCyNQwuW3YwrGt6qIUEbpc+YT1Mffnarn32mIOUHs+9kA07PyPOzUnak7I9uJQtcg==",
       "requires": {
         "better-ajv-errors": "^0.6.1",
         "call-me-maybe": "^1.0.1",
         "node-fetch-h2": "^2.3.0",
         "node-readfiles": "^0.2.0",
         "oas-kit-common": "^1.0.7",
-        "oas-resolver": "^2.2.5",
+        "oas-resolver": "^2.2.7",
         "oas-schema-walker": "^1.1.2",
-        "oas-validator": "^3.3.1",
-        "reftools": "^1.0.8",
-        "yaml": "^1.3.1",
+        "oas-validator": "^3.3.3",
+        "reftools": "^1.0.10",
+        "yaml": "^1.7.2",
         "yargs": "^12.0.5"
       },
       "dependencies": {
@@ -5446,45 +5454,6 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
-    "term-size": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
-      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
-      "requires": {
-        "execa": "^0.7.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "execa": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-          "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
-        }
-      }
-    },
     "test-exclude": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
@@ -5572,7 +5541,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -5622,11 +5590,6 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
-    "type-fest": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
-    },
     "uglify-js": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
@@ -5655,38 +5618,53 @@
       }
     },
     "unmock": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/unmock/-/unmock-0.3.8.tgz",
-      "integrity": "sha512-3797GFmN2YgZrj82CRb3U9J7tjacycwdKN4vyvpyAAh3XmFGDN7Q2NonnxGwq2NtHVr5iNZI5HMbjp6xwJTAuw==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/unmock/-/unmock-0.3.14.tgz",
+      "integrity": "sha512-fqZH0FX0EMRS2BZdvElaymy+wVdmNA5ymcbdhxdwa85hc/B0rO3MGI2WIYyLZYgxxz3YSD8LHRUFQ5M7U6A7Rg==",
       "requires": {
-        "unmock-cli": "^0.3.8",
-        "unmock-core": "^0.3.8"
+        "unmock-browser": "^0.3.14",
+        "unmock-cli": "^0.3.14",
+        "unmock-core": "^0.3.14",
+        "unmock-node": "^0.3.14"
       },
       "dependencies": {
         "unmock-cli": {
-          "version": "0.3.8",
-          "resolved": "https://registry.npmjs.org/unmock-cli/-/unmock-cli-0.3.8.tgz",
-          "integrity": "sha512-lHhSQhddoKV9ut0owe3dO6uyVNEmAUhN2HOrVYhAHjbzRHAgHOcAOpVnmrnTx7oP3eZ+j3kkoHXAwIFsN8YCDQ==",
+          "version": "0.3.14",
+          "resolved": "https://registry.npmjs.org/unmock-cli/-/unmock-cli-0.3.14.tgz",
+          "integrity": "sha512-MdDCwTC2++F7RPW1pJz+yaWl6zoSkWpBV87G1iR1mQaGRuA6RisaB5xs0F/ocRgr4N9u6s3WQoY7jPTy2y3VWw==",
           "requires": {
+            "@types/readline-sync": "^1.4.3",
+            "chalk": "^2.4.2",
             "commander": "^2.20.0",
             "glob": "^7.1.3",
-            "unmock-core": "^0.3.8"
+            "readline-sync": "^1.4.10",
+            "unmock-core": "^0.3.14",
+            "unmock-node": "^0.3.14"
           }
         }
       }
     },
-    "unmock-core": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/unmock-core/-/unmock-core-0.3.8.tgz",
-      "integrity": "sha512-r6JgtRSNbD9lMzCojKEVOPe8smnPiwTu+GZg3rjvTBHrNWNPQfIyzr89Fh1HsyiAyR4dc6AqSj/rZqwQJhRV2Q==",
+    "unmock-browser": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/unmock-browser/-/unmock-browser-0.3.14.tgz",
+      "integrity": "sha512-3lJvfr8rOVO5xgVqihoPsqfHjLsUM9oVAAhRbdduaUFtd2KSBbdXuzerFlewZCA0sNujUMyHL0DnpgTYhZ1IXw==",
       "requires": {
-        "@types/node": "^12.7.8",
-        "@types/node-fetch": "^2.5.2",
+        "buffer": "^5.4.3",
+        "unmock-core": "^0.3.14",
+        "unmock-fetch": "^0.3.14"
+      }
+    },
+    "unmock-core": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/unmock-core/-/unmock-core-0.3.14.tgz",
+      "integrity": "sha512-HJFSpJlQCzNDOGiVBnqLymIYyc5GaZBdvnHA6rghpoZqVXlME553diPe7h/RY77N0s8QKq7HHlrrpE3sc4A4Bw==",
+      "requires": {
+        "@meeshkanml/json-schema-faker": "^0.0.2",
+        "@meeshkanml/jsonschema": "^0.0.1",
         "@types/sinon": "^7.0.13",
+        "@types/whatwg-url": "^6.4.0",
         "ajv": "^6.10.0",
-        "app-root-path": "^2.2.1",
         "axios": "^0.18.0",
-        "boxen": "3.2.0",
         "chalk": "^2.4.2",
         "debug": "^4.1.1",
         "expect": "^24.9.0",
@@ -5694,29 +5672,20 @@
         "fp-ts": "^2.0.5",
         "ini": "^1.3.5",
         "io-ts": "^2.0.1",
-        "js-yaml": "^3.13.1",
         "json-pointer": "^0.6.0",
         "json-schema-deref-sync": "^0.10.1",
-        "json-schema-faker": "^0.5.0-rc17",
         "json-schema-poet": "0.0.9",
         "json-schema-strictly-typed": "0.0.14",
-        "jsonschema": "^1.2.4",
         "loas3": "^0.1.4",
         "lodash": "^4.17.14",
         "minimatch": "^3.0.4",
-        "mitm": "^1.7.0",
-        "mkdirp": "^0.5.1",
         "monocle-ts": "^2.0.0",
-        "node-fetch": "^2.6.0",
-        "openapi-refinements": "^0.3.8",
+        "openapi-refinements": "^0.3.12",
         "query-string": "^6.8.3",
-        "querystring": "^0.2.0",
-        "readable-stream": "^3.4.0",
         "seedrandom": "^3.0.3",
-        "shimmer": "^1.2.1",
         "sinon": "^7.4.1",
         "swagger2openapi": "^5.3.0",
-        "uuid": "^3.3.2",
+        "whatwg-url": "^7.0.0",
         "winston": "^3.2.1"
       },
       "dependencies": {
@@ -5746,7 +5715,105 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "whatwg-url": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+          "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
         }
+      }
+    },
+    "unmock-fetch": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/unmock-fetch/-/unmock-fetch-0.3.14.tgz",
+      "integrity": "sha512-fKtNsWlxPCnPboA8WsKc41JO2JmB2sOcXnC5SsJdTAAlZhj4nXXXHq4z2rJO1UV1dl8FPkfXVhTGj3UMzaFGXA==",
+      "requires": {
+        "@types/debug": "^4.1.5",
+        "@types/url-parse": "^1.4.3",
+        "cross-fetch": "^3.0.4",
+        "debug": "^4.1.1",
+        "unmock-core": "^0.3.14",
+        "url-parse": "^1.4.7"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "unmock-jest-runner": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/unmock-jest-runner/-/unmock-jest-runner-0.0.0.tgz",
+      "integrity": "sha512-eYPKDxBOPifQXSn+tFHCAFAgEK/a18pt6leGGbMmP/tVKAg8yOw5Mhr1C7duAuTM35qNc2hDwPKx06AX2uJiMA==",
+      "dev": true,
+      "requires": {
+        "unmock": "^0.3.14",
+        "unmock-runner": "^0.3.14"
+      }
+    },
+    "unmock-node": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/unmock-node/-/unmock-node-0.3.14.tgz",
+      "integrity": "sha512-vwPtRIv99VqnBtDbe3LVwAly0WH1FK13EjiJhv/VPTrxjuSdozmv+ggwShBwQPjtg2/kAdl4h57uMQ1TP6D1KQ==",
+      "requires": {
+        "@types/node": "^12.7.8",
+        "@types/node-fetch": "^2.5.2",
+        "app-root-path": "^2.2.1",
+        "debug": "^4.1.1",
+        "js-yaml": "^3.13.1",
+        "lodash": "^4.17.14",
+        "mitm": "^1.7.0",
+        "mkdirp": "^0.5.1",
+        "node-fetch": "^2.6.0",
+        "readable-stream": "^3.4.0",
+        "shimmer": "^1.2.1",
+        "unmock-core": "^0.3.14",
+        "uuid": "^3.3.2",
+        "winston": "^3.2.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.12.27",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.27.tgz",
+          "integrity": "sha512-odQFl/+B9idbdS0e8IxDl2ia/LP8KZLXhV3BUeI98TrZp0uoIzQPhGd+5EtzHmT0SMOIaPd7jfz6pOHLWTtl7A=="
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "unmock-runner": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/unmock-runner/-/unmock-runner-0.3.14.tgz",
+      "integrity": "sha512-jYot8yLk7j2DWGZRx6qjaO8D5qQOQ/wKlXy1dtt9YzcED1CzmZwPDDCaS3UXWoqjJQApUhXzwnFEk2v/bA6BIw==",
+      "dev": true,
+      "requires": {
+        "unmock-core": "^0.3.14"
       }
     },
     "unset-value": {
@@ -5797,6 +5864,31 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+    },
+    "url": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        }
+      }
+    },
+    "url-parse": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
+      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
     },
     "use": {
       "version": "3.1.1",
@@ -5870,8 +5962,7 @@
     "webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-      "dev": true
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
     },
     "whatwg-encoding": {
       "version": "1.0.5",
@@ -5881,6 +5972,11 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
+    },
+    "whatwg-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",
@@ -5912,38 +6008,6 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
-    "widest-line": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
-      "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
-      "requires": {
-        "string-width": "^2.1.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
-      }
-    },
     "winston": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/winston/-/winston-3.2.1.tgz",
@@ -5970,9 +6034,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -6046,17 +6110,12 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
     },
-    "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-    },
     "yaml": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.7.0.tgz",
-      "integrity": "sha512-BEXCJKbbJmDzjuG4At0R4nHJKlP81hxoLQqUCaxzqZ8HHgjAlOXbiOHVCQ4YuQqO/rLR8HoQ6kxGkYJ3tlKIsg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.7.2.tgz",
+      "integrity": "sha512-qXROVp90sb83XtAoqE8bP9RwAkTTZbugRUTm5YeFCBfNRPEp2YzTeqWiz7m5OORHzEvrA/qcGS8hp/E+MMROYw==",
       "requires": {
-        "@babel/runtime": "^7.5.5"
+        "@babel/runtime": "^7.6.3"
       }
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "jest": "^24.9.0"
+    "jest": "^24.9.0",
+    "unmock-jest-runner": "0.0.0"
   },
   "dependencies": {
     "axios": "^0.19.0",
-    "unmock": "^0.3.8"
+    "unmock": "^0.3.14"
   }
 }


### PR DESCRIPTION
Replace instances of imported unmock runner with new [`unmock-jest-runner`](https://www.npmjs.com/package/unmock-jest-runner) package.

Should be merged at the same time as https://github.com/unmock/katacoda-scenarios/pull/7

Related to https://github.com/Meeshkan/unmock-js/issues/299